### PR TITLE
Feature/commands usage improvement

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -20,19 +20,19 @@ var copyQueueLen uint
 var responseChan chan tasks.BackupFileResponse
 
 func init() {
-	cpCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "project root path")
-	cpCmd.Flags().StringVarP(&batchesDirPath, "batches-dir-path", "b", "", "copy batches directory path")
+	cpCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "mandatory flag: project root path")
+	cpCmd.Flags().StringVarP(&batchesDirPath, "batches-dir-path", "b", "", "mandatory flag: copy batches directory path")
 	cpCmd.Flags().UintVarP(&copyQueueLen, "copy-queue-len", "q", 5, "copy queue length")
 	rootCmd.AddCommand(cpCmd)
 }
 
 var cpCmd = &cobra.Command{
-	Use:   "cp",
+	Use:   "cp [source-dir-path] [target-dir-path]",
 	Short: "copy files",
 	Long:  "copy files recursively from source to target dir",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
-			return fmt.Errorf("arguments mismatch, expecting 2 arguments")
+			return fmt.Errorf("arguments mismatch, expecting 2 arguments: [source-dir-path] [target-dir-path]")
 		}
 		cfg.Src = args[0]
 		cfg.Target = args[1]

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -38,7 +38,7 @@ var diffCmd = &cobra.Command{
 }
 
 func init() {
-	diffCmd.PersistentFlags().UintVarP(&cfg.NumWorkers, "workers", "w", 2, "number of concurrent file-copy workers")
-	diffCmd.PersistentFlags().StringVarP(&timeString, "time", "t", "", "reference time with format: 2006-01-02T15:04:05")
+	diffCmd.Flags().UintVarP(&cfg.NumWorkers, "workers", "w", 2, "number of concurrent file-copy workers")
+	diffCmd.Flags().StringVarP(&timeString, "time", "t", "", "reference time with format: 2006-01-02T15:04:05")
 	rootCmd.AddCommand(diffCmd)
 }

--- a/cmd/full.go
+++ b/cmd/full.go
@@ -2,9 +2,21 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
+
+var slicesWorkDirPath string
+
+func init() {
+	// slice dependency
+	fullCmd.Flags().UintVarP(&batchSize, "batch-size", "s", defaultBatchSize, "maximum number of files in a batch")
+
+	// cp dependency
+	fullCmd.Flags().UintVarP(&copyQueueLen, "copy-queue-len", "q", 5, "copy queue length")
+
+	rootCmd.AddCommand(fullCmd)
+}
 
 var fullCmd = &cobra.Command{
 	Use:   "full [source-dir-path] [target-dir-path]",
@@ -18,14 +30,44 @@ var fullCmd = &cobra.Command{
 		cfg.Target = args[1]
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("numWorkers: %v\n", cfg.NumWorkers)
-		fmt.Printf("src: %v\n", cfg.Src)
-		fmt.Printf("target: %v\n", cfg.Target)
-	},
-}
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// init
+		if err := initCmd.RunE(cmd, args); err != nil {
+			return err
+		}
 
-func init() {
-	fullCmd.PersistentFlags().UintVarP(&cfg.NumWorkers, "workers", "w", 2, "number of concurrent file-copy workers")
-	rootCmd.AddCommand(fullCmd)
+		slicesWorkDirPath = filepath.Join(rootDirPath, "slice")
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// list
+		listDirPath = filepath.Join(rootDirPath, listDirName)
+		if err := lsCmd.RunE(cmd, args); err != nil {
+			return err
+		}
+
+		// skeleton
+		skeletonWorkDir = filepath.Join(rootDirPath, dirSkeletonDirName)
+		dirsListFilePath = listDirsPath
+		if err := skeletonCmd.RunE(cmd, args); err != nil {
+			return err
+		}
+
+		// slice
+		filesListFilePath = listFilesPath
+		if err := sliceCmd.PreRunE(cmd, args); err != nil {
+			return err
+		}
+		if err := sliceCmd.RunE(cmd, args); err != nil {
+			return err
+		}
+
+		// cp
+		batchesDirPath = batchesTargetDirPath
+		if err := cpCmd.RunE(cmd, args); err != nil {
+			return err
+		}
+
+		return nil
+	},
 }

--- a/cmd/full.go
+++ b/cmd/full.go
@@ -2,16 +2,17 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
 var fullCmd = &cobra.Command{
-	Use:   "full",
+	Use:   "full [source-dir-path] [target-dir-path]",
 	Short: "full backup",
 	Long:  "with full backup all files and folders are copied from src to target",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
-			return fmt.Errorf("arguments mismatch, expecting 2 arguments")
+			return fmt.Errorf("arguments mismatch, expecting 2 arguments: [source-dir-path] [target-dir-path]")
 		}
 		cfg.Src = args[0]
 		cfg.Target = args[1]

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,12 +26,9 @@ const (
 	skeletonErrorsFileNamePattern = "skeleton_errors_%s.log"
 	sliceBatchFileNamePattern     = "batch_%d.log"
 	sliceErrorsFileNamePattern    = "slice_errors_%s.log"
-	fileTasksDirName              = "file_batches"
-	copyLogDirPattern             = "file_copy_%s" + string(filepath.Separator) + "copy_log"
-	copyErrorLogDirPattern        = "file_copy_%s" + string(filepath.Separator) + "error_log"
+	slicesWorkDirName             = "slices"
+	copyLogDirPattern             = "copy" + string(filepath.Separator) + "copy_logs_%s"
 	copyBatchLogFileNamePattern   = "copy_batch_%d.log"
-	copyErrorLogFileName          = "copy_error.log"
-	errorsDirName                 = "errors"
 	operationLogFileName          = "oplog.log"
 	defaultPerm                   = 0755
 )
@@ -47,8 +44,6 @@ var initCmd = &cobra.Command{
 	Short: "init rb project",
 	Long:  "init initialised a new backup project",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_ = writeOpLog("init start")
-
 		if err := setup(); err != nil {
 			_ = writeOpLog("init error")
 			return err
@@ -74,8 +69,9 @@ func setup() error {
 	if err = os.Chdir(rootDirName); err != nil {
 		return fmt.Errorf("failed to change work dir to %s", rootDirName)
 	}
+	_ = writeOpLog("init start")
 
-	subDirs := []string{listDirName, dirSkeletonDirName, fileTasksDirName, errorsDirName}
+	subDirs := []string{listDirName, dirSkeletonDirName, slicesWorkDirName}
 	for _, subDir := range subDirs {
 		if err = os.Mkdir(subDir, defaultPerm); err != nil {
 			return fmt.Errorf("failed to create directory %s", subDir)

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -15,6 +15,8 @@ func init() {
 }
 
 var listDirPath string
+var listFilesPath string
+var listDirsPath string
 
 var lsCmd = &cobra.Command{
 	Use:   "ls [source-dir-path]",
@@ -29,13 +31,15 @@ var lsCmd = &cobra.Command{
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := initCmd.RunE(cmd, args); err != nil {
-			return err
+		if err := validateWorkDir(true); err != nil {
+			if err = initCmd.RunE(cmd, args); err != nil {
+				return err
+			}
 		}
 
 		listDirPath = filepath.Join(rootDirPath, listDirName)
 
-		if err :=  os.Chdir(listDirPath); err != nil {
+		if err := os.Chdir(listDirPath); err != nil {
 			return err
 		}
 		return nil
@@ -80,21 +84,25 @@ func listRunCommand(cmd *cobra.Command, args []string) error {
 }
 
 func createFilesForList() (dirs, files, errs *os.File, err error) {
-	dirs, err = os.Create(fmt.Sprintf(listedDirsFileNamePattern, time.Now().Format(timeDateFormat)))
+	now := time.Now()
+	listDirsName := fmt.Sprintf(listedDirsFileNamePattern, now.Format(timeDateFormat))
+	dirs, err = os.Create(listDirsName)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	listDirsPath = filepath.Join(listDirPath, listDirsName)
 
-	files, err = os.Create(fmt.Sprintf(listedFilesFileNamePattern, time.Now().Format(timeDateFormat)))
+	listFilesName := fmt.Sprintf(listedFilesFileNamePattern, now.Format(timeDateFormat))
+	files, err = os.Create(listFilesName)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	listFilesPath = filepath.Join(listDirPath, listFilesName)
 
-	errs, err = os.Create(fmt.Sprintf(listErrorsFileNamePattern, time.Now().Format(timeDateFormat)))
+	errs, err = os.Create(fmt.Sprintf(listErrorsFileNamePattern, now.Format(timeDateFormat)))
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	return dirs, files, errs, nil
 }
-

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/AppleGamer22/recursive-backup/internal/manager"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/AppleGamer22/recursive-backup/internal/manager"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -16,12 +17,12 @@ func init() {
 var listDirPath string
 
 var lsCmd = &cobra.Command{
-	Use:   "ls",
+	Use:   "ls [source-dir-path]",
 	Short: "list all source elements",
 	Long:  "list source recursively for all directories and files",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
-			return fmt.Errorf("arguments mismatch, expecting 1 argument")
+			return fmt.Errorf("arguments mismatch, expecting 1 argument: [source-dir-path]")
 		}
 		cfg.Src = args[0]
 
@@ -43,8 +44,6 @@ var lsCmd = &cobra.Command{
 }
 
 func listRunCommand(cmd *cobra.Command, args []string) error {
-	fmt.Printf("src: %v\n", cfg.Src)
-
 	operationLogLine := "list start"
 	if err := writeOpLog(operationLogLine); err != nil {
 		return err

--- a/cmd/skeleton.go
+++ b/cmd/skeleton.go
@@ -15,19 +15,19 @@ var skeletonWorkDir string
 var dirsListFilePath string
 
 func init() {
-	skeletonCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "project root path")
-	skeletonCmd.Flags().StringVarP(&dirsListFilePath, "dirs-list-file-path", "d", "", "directories list file path")
+	skeletonCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "mandatory flag: project root path")
+	skeletonCmd.Flags().StringVarP(&dirsListFilePath, "dirs-list-file-path", "d", "", "mandatory flag: directories list file path")
 	rootCmd.AddCommand(skeletonCmd)
 
 }
 
 var skeletonCmd = &cobra.Command{
-	Use:   "skeleton",
+	Use:   "skeleton [source-dir-path] [target-dir-path]",
 	Short: "create target directory skeleton",
 	Long:  "create directory skeleton in target",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
-			return fmt.Errorf("arguments mismatch, expecting 2 arguments")
+			return fmt.Errorf("arguments mismatch, expecting 2 arguments: [source-dir-path] [target-dir-path]")
 		}
 		cfg.Src = args[0]
 		cfg.Target = args[1]
@@ -42,8 +42,6 @@ var skeletonCmd = &cobra.Command{
 }
 
 func skeletonRunCommand(cmd *cobra.Command, args []string) error {
-	fmt.Printf("src: %v\n", cfg.Src)
-
 	operationLogLine := "directory skeleton build start"
 	if err := writeOpLog(operationLogLine); err != nil {
 		return err

--- a/cmd/slice.go
+++ b/cmd/slice.go
@@ -19,8 +19,8 @@ var filesListFilePath string
 var batchSize uint
 
 func init() {
-	sliceCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "project root path")
-	sliceCmd.Flags().StringVarP(&filesListFilePath, "files-list", "f", "", "files list file path")
+	sliceCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "mandatory flag: project root path")
+	sliceCmd.Flags().StringVarP(&filesListFilePath, "files-list-file-path", "f", "", "mandatory flag: files list file path")
 	sliceCmd.Flags().UintVarP(&batchSize, "batch-size", "b", defaultBatchSize, "maximum number of files in a batch")
 	rootCmd.AddCommand(sliceCmd)
 }
@@ -36,9 +36,13 @@ var sliceCmd = &cobra.Command{
 		return nil
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(rootDirPath) == 0 || len(filesListFilePath) == 0{
-			return errors.New("bad input")
+		if len(rootDirPath) == 0 {
+			return errors.New("project root path flag must be specified")
 		}
+		if len(filesListFilePath) == 0 {
+			return errors.New("files-list-file-path flag must be specified")
+		}
+
 		now := time.Now().Format(timeDateFormat)
 		batchesDirName := fmt.Sprintf(sliceBatchesDirNamePattern, now)
 		batchesTargetDirPath = filepath.Join(rootDirPath, batchesDirName)

--- a/cmd/slice.go
+++ b/cmd/slice.go
@@ -21,7 +21,7 @@ var batchSize uint
 func init() {
 	sliceCmd.Flags().StringVarP(&rootDirPath, "project", "p", "", "mandatory flag: project root path")
 	sliceCmd.Flags().StringVarP(&filesListFilePath, "files-list-file-path", "f", "", "mandatory flag: files list file path")
-	sliceCmd.Flags().UintVarP(&batchSize, "batch-size", "b", defaultBatchSize, "maximum number of files in a batch")
+	sliceCmd.Flags().UintVarP(&batchSize, "batch-size", "s", defaultBatchSize, "maximum number of files in a batch")
 	rootCmd.AddCommand(sliceCmd)
 }
 


### PR DESCRIPTION
Commands improvements

`ℵ₀ ~/dev/recursive-backup/bin/rb_1.0.0_linux_amd64 full -q 3 -s 4 ~/test/srcs ~/test/target2`
Resulted with

ℵ₀ tree rb_20211107T195751

```rb_20211107T195751
├── copy
│   └── copy_logs_20211107T195751
│       ├── copy_batch_1.log
│       └── copy_batch_2.log
├── dirs
│   ├── skeleton_dirs_20211107T195751.log
│   └── skeleton_errors_20211107T195751.log
├── list
│   ├── list_dirs_20211107T195751.log
│   ├── list_errors_20211107T195751.log
│   └── list_files_20211107T195751.log
├── oplog.log
├── slice
│   ├── batches_20211107T195751
│   │   ├── batch_1.log
│   │   └── batch_2.log
│   └── errors_20211107T195751
│       └── slice_errors_20211107T195751.log
└── slices```

And with:

```
ℵ₀ tree target2
target2
├── empty
│   └── emptyaswell
├── source1
│   └── omri.txt
├── source2
│   └── amir.log
└── source3
    ├── barfoo.log
    ├── src31
    │   ├── bar.txt
    │   └── foo.txt
    └── src32
        └── foobar.txt
```

