### PR TITLE
removed cmd from SOURCES in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # target usb, source smb
 
 VERSION:=1.0.0
-SOURCES:=./internal/*,./cmd
+SOURCES:=./internal/*
 BIN:=./bin
 BASE:=rb_$(VERSION)
 LINUX=$(BASE)_linux_amd64

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,21 @@
 # target usb, source smb
 
 VERSION:=1.0.0
-SOURCES:=./internal/*
 BIN:=./bin
 BASE:=rb_$(VERSION)
 LINUX=$(BASE)_linux_amd64
 DARWIN=$(BASE)_darwin_amd64
 WINDOWS=$(BASE)_windows_amd64.exe
 
-all: build test
+all: test build
 
 build: $(LINUX) $(DARWIN) $(WINDOWS)
 
 test:
-		@echo
-		@echo "Testing $(VERSION)"
-		go test -v -cover $(SOURCES)
+		@echo "Testing $(VERSION) internal"
+		go test -v -cover ./internal/*
+		@echo "Testing $(VERSION) cmd"
+		go test -v -cover ./cmd/*
 
 linux: $(LINUX)
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,7 @@ module github.com/AppleGamer22/recursive-backup
 go 1.16
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
A fix for the following error:
```
ℵ₀ make
env GOOS=linux GOARCH=amd64 go build -v -o ./bin/rb_1.0.0_linux_amd64
env GOOS=darwin GOARCH=amd64 go build -v -o ./bin/rb_1.0.0_darwin_amd64
internal/unsafeheader
internal/goexperiment
internal/race
runtime/internal/sys
internal/cpu
sync/atomic
internal/abi
runtime/internal/atomic
unicode
unicode/utf8
internal/itoa
runtime/internal/math
math/bits
encoding
unicode/utf16
internal/nettrace
internal/bytealg
math
runtime
internal/reflectlite
sync
internal/testlog
internal/singleflight
errors
sort
path
internal/oserror
io
strconv
vendor/golang.org/x/net/dns/dnsmessage
syscall
bytes
strings
reflect
bufio
regexp/syntax
internal/syscall/execenv
internal/syscall/unix
time
regexp
io/fs
context
internal/poll
os
internal/fmtsort
encoding/binary
github.com/AppleGamer22/recursive-backup/internal/validationhelpers
fmt
path/filepath
vendor/golang.org/x/net/route
encoding/base64
net
github.com/AppleGamer22/recursive-backup/internal/rberrors
encoding/hex
database/sql/driver
encoding/csv
net/url
text/template/parse
encoding/json
flag
text/template
github.com/spf13/pflag
github.com/go-ozzo/ozzo-validation/v4
github.com/AppleGamer22/recursive-backup/internal/tasks
github.com/AppleGamer22/recursive-backup/internal/manager
github.com/spf13/cobra
github.com/AppleGamer22/recursive-backup/cmd
github.com/AppleGamer22/recursive-backup
env GOOS=windows GOARCH=amd64 go build  -v -o ./bin/rb_1.0.0_windows_amd64.exe
internal/unsafeheader
internal/goexperiment
internal/race
runtime/internal/sys
sync/atomic
runtime/internal/atomic
internal/abi
internal/cpu
unicode/utf8
unicode
internal/itoa
runtime/internal/math
math/bits
internal/syscall/windows/sysdll
unicode/utf16
encoding
internal/nettrace
internal/bytealg
math
runtime
internal/reflectlite
sync
internal/testlog
internal/singleflight
errors
sort
internal/oserror
io
path
strconv
vendor/golang.org/x/net/dns/dnsmessage
syscall
strings
bytes
reflect
bufio
regexp/syntax
internal/syscall/windows
internal/syscall/windows/registry
time
regexp
internal/syscall/execenv
context
io/fs
internal/poll
internal/fmtsort
encoding/binary
os
encoding/base64
github.com/AppleGamer22/recursive-backup/internal/validationhelpers
github.com/inconshreveable/mousetrap
path/filepath
fmt
net
github.com/AppleGamer22/recursive-backup/internal/rberrors
net/url
database/sql/driver
text/template/parse
encoding/csv
encoding/json
encoding/hex
flag
text/template
github.com/spf13/pflag
github.com/go-ozzo/ozzo-validation/v4
github.com/AppleGamer22/recursive-backup/internal/tasks
github.com/AppleGamer22/recursive-backup/internal/manager
github.com/spf13/cobra
github.com/AppleGamer22/recursive-backup/cmd
github.com/AppleGamer22/recursive-backup

Testing 1.0.0
go test -v -cover ./internal/*,./cmd
stat /home/amir/dev/recursive-backup/internal/*,./cmd: directory not found
make: *** [Makefile:20: test] Error 1

```